### PR TITLE
Add functionality to support genbank files when adding reference to sequences

### DIFF
--- a/subworkflows/local/post_alignment_process/main.nf
+++ b/subworkflows/local/post_alignment_process/main.nf
@@ -10,22 +10,22 @@ workflow POST_ALIGNMENT_PROCESS {
     namefile_tuples
     nt_tuples
     add_ref_seq
-    reference
+    ch_reference
 
     main:
     def samples = aligned_tuples
     def nt_samples = nt_tuples
-    def ch_ref = channel.value(reference)
+    // def ch_ref = channel.value(ch_reference)
     if (add_ref_seq) {
         TRANSLATE_REFERENCE(
-            channel.of([reference, ["sample_id": "ref"]])
+            ch_reference
         )
         MAFFT_ADD(
             aligned_tuples,
             TRANSLATE_REFERENCE.out.sample_tuple.collect().map { ref_file, _meta -> ref_file },
         )
         ADD_SEQUENCES(
-            nt_tuples.merge(ch_ref) { sample, ref -> tuple([sample[0], ref], sample[1]) }
+            nt_tuples.merge(ch_reference) { sample, ref -> tuple([sample[0], ref[0]], sample[1]) }
         )
         samples = MAFFT_ADD.out.sample_tuple
         nt_samples = ADD_SEQUENCES.out.fasta_tuple
@@ -49,5 +49,5 @@ workflow POST_ALIGNMENT_PROCESS {
     )
 
     emit:
-    revserse_translated_tuples = REVERSE_TRANSLATE.out.sample_tuple
+    reverse_translated_tuples = REVERSE_TRANSLATE.out.sample_tuple
 }

--- a/subworkflows/local/pre_alignment_process/main.nf
+++ b/subworkflows/local/pre_alignment_process/main.nf
@@ -7,7 +7,7 @@ workflow PRE_ALIGNMENT_PROCESSING {
     take:
     nt_sample_tuple // file(FASTA_NT_FILTERED), meta 
     val_addRefToSeqs // bool: indicates that a reference should be added to samples prior to alignment
-    reference_to_add // file: the reference that should be added
+    ch_reference_to_add // file: the reference that should be added
 
     main:
 
@@ -23,7 +23,7 @@ workflow PRE_ALIGNMENT_PROCESSING {
     if (val_addRefToSeqs) {
 
         TRANSLATE_REFERENCE(
-            channel.of([reference_to_add, ["sample_id": "ref"]])
+            ch_reference_to_add
         )
         ADD_SEQUENCES(
             COLLAPSE.out.sample_tuple.merge(TRANSLATE_REFERENCE.out.sample_tuple.collect()) { sample, ref ->

--- a/workflows/pipeline.nf
+++ b/workflows/pipeline.nf
@@ -49,25 +49,41 @@ workflow HIV_SEQ_PIPELINE {
     def add_ref_before_align = params.add_reference_to_sequences == "BEFORE"
     def add_ref_after_align = params.add_reference_to_sequences == "AFTER"
 
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // REFERENCE SEQUENCE CONVERSION AND PARSING
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     // We need to check if the user wants to add a different reference to the sequences 
     def reference_to_add = params.reference_to_add
 
-    if (!params.reference_to_add) {
+    if (!reference_to_add) {
         reference_to_add = params.reference_file
     }
 
-    def reference_to_add_file = file(reference_to_add)
-    def ref_seq_name = reference_to_add_file.text.split("\n").find { line -> line.startsWith('>') }.substring(1)
+
+    def ref_to_add_is_genbank = file(reference_to_add).extension == "gb"
+
+    (genbank_ref, fasta_ref) = ref_to_add_is_genbank ? [channel.of(reference_to_add), channel.empty()] : [channel.empty(), channel.of(reference_to_add)]
+
+    EXTRACT_SEQ_FROM_GB(
+        genbank_ref,
+        regionOfInterest,
+    )
+
+    def ref_seq_name = ""
+
+    if (ref_to_add_is_genbank) {
+        ref_seq_name = regionOfInterest
+    }
+    else {
+        ref_seq_name = file(reference_to_add).text.split("\n").find { line -> line.startsWith('>') }.substring(1)
+    }
+
     additionalMetadata.put("ref_seq_name", ref_seq_name)
 
-    if (reference_to_add_file.extension == "gb") {
-        EXTRACT_SEQ_FROM_GB(
-            reference_to_add_file,
-            ref_seq_name,
-        )
-        reference_to_add_file = EXTRACT_SEQ_FROM_GB.out.extracted_sequence_fasta
-    }
+    def ref_meta_dict = ["sample_id": ref_seq_name, "num_seqs": 1]
+    def ch_refToAdd = EXTRACT_SEQ_FROM_GB.out.extracted_sequence_fasta.mix(fasta_ref).map { ref -> [ref, ref_meta_dict] }
+
 
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // BUILD SAMPLESHEET
@@ -115,7 +131,7 @@ workflow HIV_SEQ_PIPELINE {
     PRE_ALIGNMENT_PROCESSING(
         FILTER_FUNCTIONAL_SEQUENCES.out.filtered_samples,
         add_ref_before_align,
-        reference_to_add_file,
+        ch_refToAdd,
     )
 
     ALIGN(
@@ -127,7 +143,7 @@ workflow HIV_SEQ_PIPELINE {
         PRE_ALIGNMENT_PROCESSING.out.namefile_tuples,
         FILTER_FUNCTIONAL_SEQUENCES.out.filtered_samples,
         add_ref_after_align,
-        reference_to_add_file,
+        ch_refToAdd,
     )
 
     if (multi_timepoint_alignment) {


### PR DESCRIPTION
This PR adds ability to add a reference to sequences when that reference is given in genbank format. It is assumed that the feature in the genbank file
has the same name as the region of interest parameter
- **:sparkles: Add ability to handle when ref is handed as genbank file to add to sequences**
- **:art: Fixes to allow optional processing of genbank reference seq**
